### PR TITLE
Wait for LastUpdateStatus to become Successful before proceeding with release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ deploy: package setup
 	aws lambda update-function-code --function-name $(LAMBDA_FUNCTION_NAME) --zip-file fileb://$(LAMBDA_FUNCTION_NAME).zip
 
 release: deploy
+	while status=$$(aws lambda get-function --function-name $(LAMBDA_FUNCTION_NAME) --query Configuration.LastUpdateStatus --output text); do \
+		[ "$$status" != InProgress ] && break; \
+		sleep 1; \
+	done; \
+	echo LastUpdateStatus: "$${status:-(unknown)}"; \
+	[ "$$status" = Successful ]
 	aws lambda publish-version --function-name $(LAMBDA_FUNCTION_NAME)
 
 invoke:


### PR DESCRIPTION
Thank you so much for sharing this Makefile, @olsaki! I am using a heavily customised and stripped down version of it in my project, but this Makefile was a **great** starting point. In order that others will be able to get off the ground as quickly as I did, please accept this PR, or future users will see the following error:

```
An error occurred (ResourceConflictException) when calling the PublishVersion operation: The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:…
```

Retrying `make release` again is not going to make the problem go away (because it depends on `deploy`), and a manual `aws lambda publish-version` would be required.